### PR TITLE
feat(js): adding js rule s39 'batch multiple css changes'

### DIFF
--- a/docs/rules/multiple-css-changes.md
+++ b/docs/rules/multiple-css-changes.md
@@ -1,0 +1,38 @@
+# Batch css changes in js (s39)
+
+
+## Rule Details
+
+This rule aims to batch multiple CSS properties changes at once
+
+To limit the number of repaint/reflow, it is advised to batch style modifications by adding a 
+class containing all style changes that will generate a unique reflow
+
+Examples of **incorrect** code for this rule:
+
+```html
+<script>
+    element.style.height = "800px";
+    element.style.width = "600px";
+    element.style.color = "red";
+</script>
+
+```
+
+Examples of **correct** code for this rule:
+
+```html
+<style>
+    .in-error {
+        color: red;
+        height: 800px;
+        width: 800px;
+    }
+</style>
+
+<script>
+    element.addClass('in-error');
+</script>
+
+```
+

--- a/lib/rules/js/multiple-css-changes.js
+++ b/lib/rules/js/multiple-css-changes.js
@@ -1,0 +1,65 @@
+/**
+ * @fileoverview Change multiple CSS properties at once
+ * @author Rémi BOUSSU
+ */
+ 'use strict';
+
+ //------------------------------------------------------------------------------
+ // Rule Definition
+ //------------------------------------------------------------------------------
+ 
+ module.exports = {
+     meta: {
+        type: "suggestion",
+         docs: {
+             description: `Change multiple CSS properties at once
+To limit the number of repaint/reflow, it is advised to batch style modifications by adding a 
+class containing all style changes that will generate a sole reflow`,
+             category: 'ecoCode',
+             recommended: false,
+             url: "https://collectif.greenit.fr/ecoconception-web/115-bonnes-pratiques-eco-conception_web.html R39"
+         },
+         fixable: null,
+         schema: []
+     },
+ 
+     create: function(context) {
+         function checkForStyleAssignations(node) {
+             // Are we checking an assignation on a style property
+             if(node?.left?.object?.property?.name == 'style')
+             {
+                const domElementName = node?.left?.object?.object?.name;
+                const currentRangestart = node?.left?.object?.object.range[0];
+
+                /** We get the parent AST to check if there is more than one assignation on 
+                the style of the same domElement */
+                const currentScopeASTBody = 
+                    context.getScope().block.body.length != 
+                        undefined ? 
+                            context.getScope().block.body : 
+                            context.getScope().block.body.body ;
+
+                const filtered = currentScopeASTBody.filter(
+                        e => e.type == "ExpressionStatement" &&
+                        e.expression.type == "AssignmentExpression" &&
+                        e.expression?.left?.object?.object?.name == domElementName &&
+                        e.expression?.left?.object?.property?.name == 'style'
+                    );
+
+                // De-duplication, prevents multiple alerts for each line involved
+                const isCurrentNodeTheFirstAssignation = currentRangestart <= filtered[0].expression?.left?.object?.object.range[0];
+                
+                if(filtered.length > 1 && isCurrentNodeTheFirstAssignation)
+                {
+                    context.report({
+                        node,
+                        message: "More than two style assignation",
+                      });
+                }
+             }
+         }
+         return {
+             'AssignmentExpression': checkForStyleAssignations
+         };
+     }
+ };

--- a/tests/lib/rules/js/multiple-css-changes.js
+++ b/tests/lib/rules/js/multiple-css-changes.js
@@ -1,0 +1,83 @@
+/**
+ * @fileoverview Multiple CSS change
+ * @author Rémi Boussu
+ */
+'use strict';
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+const rule = require('../../../../lib/rules/js/multiple-css-changes');
+const RuleTester = require('eslint').RuleTester;
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+var ruleTester = new RuleTester();
+ruleTester.run('multiple-css-changes', rule, {
+  valid: [
+    {
+      code: 'element.style.height = "800px";'
+    },
+    {
+      code: 
+      `element.style.height = "800px";
+      element2.style.width = "800px";`
+    },
+    {
+      code: 
+      `element.style.height = "800px";
+      function a() { element.style.width = "800px"; }
+      `
+    }
+  ],
+
+  invalid: [
+    {
+      code: 
+        `function a(element){
+          element.style.height = "800px";
+          element.style.width = "800px";
+        }`,
+      errors: [
+        {
+          message: "More than two style assignation",
+          type: 'AssignmentExpression',
+        },
+      ],
+    },
+    {
+      code: 
+      `element.style.height = "800px";
+      element.style.width = "800px";`,
+      errors: [
+        {
+          message: "More than two style assignation",
+          type: 'AssignmentExpression',
+        },
+      ],
+    },
+    {
+      code: 
+      `
+      function changeStyle()
+      {
+        var anyScopedVar;
+        element.style.any = "800px";
+        anotherChildElement.style.any = "800px";
+        anyGlobalVar.assignation = "any";
+        anyScopedVar = anyGlobalVar.assignation;
+        element.style.anyOther = "800px";
+      }
+      `,
+      errors: [
+        {
+          message: "More than two style assignation",
+          type: 'AssignmentExpression',
+        },
+      ],
+    }
+  ],
+});


### PR DESCRIPTION
This rule aims to batch multiple CSS properties changes at once

To limit the number of repaint/reflow, it is advised to batch style modifications by adding a 
class containing all style changes that will generate a unique reflow